### PR TITLE
correct startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,3 +13,5 @@ ENV NODE_ENV=production
 COPY --from=build $WORKDIR ./
 USER hmcts
 EXPOSE 3000
+
+CMD ["yarn", "serve"]

--- a/package.json
+++ b/package.json
@@ -8,12 +8,14 @@
   "main": "server/index.js",
   "scripts": {
     "start": "grunt serve",
+    "serve": "grunt serve:dist",
+    "debug": "NODE_ENV=dist grunt build && node --inspect-brk ./tmp/server/index.js",
+    "start:lb": "NODE_ENV=development node ./tmp/server/index.js",
     "test": "grunt test:intergration --force",
     "test:coverage": "grunt test:coverage --force",
     "test:a11y": "echo TODO: a11y",
     "test:smoke": "echo TODO: smoke",
     "test:functional": "echo TODO: functional",
-    "serve": "NODE_ENV=production USE_AUTH=false USE_HTTPS=false node server/index.js",
     "lint": "echo TODO: lint",
     "cichecks": "echo TODO: cichecks",
     "nsp": "nsp check"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "start": "grunt serve",
     "serve": "grunt serve:dist",
     "debug": "NODE_ENV=dist grunt build && node --inspect-brk ./tmp/server/index.js",
-    "start:lb": "NODE_ENV=development node ./tmp/server/index.js",
     "test": "grunt test:intergration --force",
     "test:coverage": "grunt test:coverage --force",
     "test:a11y": "echo TODO: a11y",


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

### JIRA link (if applicable) ###



### Change description ###
This is a copy of https://github.com/hmcts/juror-bureau/pull/123 - node env was being overridden by grunt so was start in every env as development.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
