### PR TITLE
when a juror is entering deferral dates in the public app we need to force DD/MM/YYYY

### DIFF
--- a/server/config/validation/custom-validation.js
+++ b/server/config/validation/custom-validation.js
@@ -662,7 +662,7 @@
   };
 
   validate.validators.deferralDateValid = function(value, options, key, attributes) {
-    var dateRegex = /^[0-9]{1,2}\/[0-9]{1,2}(\/[0-9]{2}|\/[0-9]{4})$/
+    var dateRegex = /^[0-9]{1,2}\/[0-9]{1,2}\/[0-9]{4}$/
       , dayMonthRegex = /^[0-9]{1,2}$/
       , yearRegex = /^[0-9]{4}$/
       , deferMoment = moment(value, 'DD/MM/YYYY')


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-8126)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=244)


### Change description ###
a juror was able to enter year as just 24 we need to force them to YYYY to conform with system validations 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
